### PR TITLE
Fix errors when running unit tests

### DIFF
--- a/src/test/http-client-base.spec.ts
+++ b/src/test/http-client-base.spec.ts
@@ -205,7 +205,7 @@ describe('http-client-base test', () => {
     expect(response["responseData"]["txHash"]).to.equal(testTxHash);
   })
 
-  it('burn service-token api test', async () => {
+  it('burn from service-token api test', async () => {
     const testContractId = "9636a07e";
     const request = {
       "ownerAddress": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",

--- a/src/test/http-client-base.spec.ts
+++ b/src/test/http-client-base.spec.ts
@@ -210,6 +210,7 @@ describe('http-client-base test', () => {
     const request = {
       "ownerAddress": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
       "ownerSecret": 'PCSO7JBIH1gWPNNR5vT58Hr2SycFSUb9nzpNapNjJFU=',
+      "fromAddress": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
       "amount": "31"
     };
 
@@ -225,13 +226,13 @@ describe('http-client-base test', () => {
 
     stub = new MockAdapter(httpClient.getAxiosInstance());
 
-    stub.onPost(`/v1/service-tokens/${testContractId}/burn`).reply(config => {
+    stub.onPost(`/v1/service-tokens/${testContractId}/burn-from`).reply(config => {
       assertHeaders(config.headers);
       expect(config.data).to.equal(JSON.stringify(request));
       return [200, receivedData];
     });
 
-    const response = await httpClient.burnServiceToken(testContractId, request);
+    const response = await httpClient.burnFromServiceToken(testContractId, request);
     expect(response["statusCode"]).to.equal(1002);
     expect(response["responseData"]["txHash"]).to.equal(testTxHash);
   })
@@ -1211,7 +1212,7 @@ describe('http-client-base test', () => {
     });
 
     const response =
-      await httpClient.walletTransactions(testAddress, pageRequest, before, after, msgType);
+      await httpClient.walletTransactions(testAddress, pageRequest, { before, after, msgType });
     expect(response["statusCode"]).to.equal(1000);
     expect(response["responseData"][0]["txhash"]).to.equal(testTxHash);
   })


### PR DESCRIPTION
Thanks for the project!


- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix errors when running unit tests.


- **What is the current behavior?** (You can also link to an open issue here)

Run `yarn run test` in the current [master](https://github.com/ryukato/developers-sdk-js/commit/7d4e6870ede4da4bf86f29f421af0a27a6c44600);

```
$ yarn run test
TSError: ⨯ Unable to compile TypeScript:
src/test/http-client-base.spec.ts:234:39 - error TS2551: Property 'burnServiceToken' does not exist on type 'HttpClient'. Did you mean 'mintServiceToken'?

234     const response = await httpClient.burnServiceToken(testContractId, request);
                                          ~~~~~~~~~~~~~~~~

  src/lib/http-client-base.ts:173:16
    173   public async mintServiceToken(
                       ~~~~~~~~~~~~~~~~
    'mintServiceToken' is declared here.
src/test/http-client-base.spec.ts:1214:77 - error TS2554: Expected 2-3 arguments, but got 5.

1214       await httpClient.walletTransactions(testAddress, pageRequest, before, after, msgType);
...
```

