### PR TITLE
Add prepublishOnly to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "cov:check": "nyc report && nyc check-coverage --lines 100 --functions 100 --branches 100",
     "version": "standard-version",
     "reset-hard": "git clean -dfx && git reset --hard && yarn",
-    "prepare-release": "run-s reset-hard test cov:check doc:html version doc:publish"
+    "prepare-release": "run-s reset-hard test cov:check doc:html version doc:publish",
+    "prepublishOnly": "run-s build"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

When I installed the npm package, I could not find the build directory in node_modules.
I don't know much about npm package, but do I need to make it `npm run build` before `npm publish` to compile TypeScript?

https://docs.npmjs.com/cli/v7/using-npm/scripts#life-cycle-scripts


- **What is the current behavior?** (You can also link to an open issue here)

https://npm.runkit.com/%40ryukato79%2Flink-developers-sdk
If you `run`, you should get the following error;

```
Error: Cannot find module '/app/available_modules/1625724624000/@ryukato79/link-developers-sdk/build/main/index.js'. Please verify that the package.json has a valid "main" entry
```
